### PR TITLE
x86_64: add libibverbs-dev to fix mlx4/mlx5 linking

### DIFF
--- a/x86_64/Dockerfile
+++ b/x86_64/Dockerfile
@@ -26,5 +26,6 @@ RUN apt-get install -yy \
   libdpdk-dev \
   dpdk \
   dpdk-dev \
+  libibverbs-dev \
   python-pip && \
 pip install coverage


### PR DESCRIPTION
Signed-off-by: Dmitry Eremin-Solenikov <dmitry.ereminsolenikov@linaro.org>
Workaround-for: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=907365