### PR TITLE
ubuntu_16.04-dpdk_18.11: build DPDK with default RTE_MACHINE

### DIFF
--- a/ubuntu_16.04-dpdk_18.11/Dockerfile
+++ b/ubuntu_16.04-dpdk_18.11/Dockerfile
@@ -39,6 +39,7 @@ RUN cd $HOME && \
     cd dpdk && \
     make config T=x86_64-native-linuxapp-gcc O=x86_64-native-linuxapp-gcc && \
     cd x86_64-native-linuxapp-gcc/ && \
+    sed -ri 's,(CONFIG_RTE_MACHINE=).*,\1"default",' .config && \
     sed -ri 's,(CONFIG_RTE_LIBRTE_PMD_PCAP=).*,\1y,' .config && \
     sed -ri 's,(CONFIG_RTE_LIBRTE_PMD_OPENSSL=).*,\1y,' .config && \
     sed -ri 's,(CONFIG_RTE_EAL_IGB_UIO=).*,\1n,' .config && \


### PR DESCRIPTION
Set RTE_MACHINE to default instead of native to support running DPDK
on different HW platforms.

Signed-off-by: Matias Elo <matias.elo@nokia.com>